### PR TITLE
Remove unused author field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "lint": "eslint . --ext js,json",
     "lint:fix": "eslint . --ext js,json --fix"
   },
-  "author": "",
   "license": "ISC",
   "dependencies": {
     "readable-stream": "^2.2.2",


### PR DESCRIPTION
This PR removes the unused author field from the `package.json` file.