### PR TITLE
Rename package to @metamask/obs-store

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ that you can subscribe to updates on.
 ## Usage
 
 ```js
-import { ObservableStore } from 'obs-store'
+import { ObservableStore } from '@metamask/obs-store'
 
 const store = new ObservableStore(initState)
 store.subscribe(function showValue(value) {
@@ -29,7 +29,7 @@ pipe its updated values out of it.
 Special behavior: Doesnt buffer outgoing updates, writes latest state to dest on pipe.
 
 ```js
-import { ObservableStore, storeAsStream } from 'obs-store'
+import { ObservableStore, storeAsStream } from '@metamask/obs-store'
 import pump from 'pump'
 
 const storeOne = new ObservableStore(initState)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "obs-store",
-  "version": "4.0.3",
+  "name": "@metamask/obs-store",
+  "version": "1.0.0",
   "description": "`ObservableStore` is a synchronous in-memory store for a single value, that you can subscribe to updates on.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Scope the package under `@metamask`.