### PR TITLE
5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [5.0.0] - 2020-12-16
+
+### Added
+
+- TypeScript types ([#27](https://github.com/MetaMask/obs-store/pull/27))
+
 ### Changed
 
-- Migrate to TypeScript ([#27](https://github.com/MetaMask/obs-store/pull/27))
+- **(BREAKING)** Rename package to `@metamask/obs-store` ([#30](https://github.com/MetaMask/obs-store/pull/30))
+- **(BREAKING)** Overhaul exports ([#29](https://github.com/MetaMask/obs-store/pull/29))
+  - All exports are now named, and exposed at the main entry point.
+  - Some export names have changed, but they should still be recognizable.
 
-[Unreleased]:https://github.com/MetaMask/obs-store/compare/v4.0.3...HEAD
-[4.0.3]:https://github.com/MetaMask/obs-store/tree/v4.0.3
+[Unreleased]:https://github.com/MetaMask/obs-store/compare/v5.0.0...HEAD
+[5.0.0]:https://github.com/MetaMask/obs-store/tree/v4.0.3...v5.0.0
+[4.0.3]:https://github.com/MetaMask/obs-store/tree/v4.0.2...v4.0.3
+[4.0.2]:https://github.com/MetaMask/obs-store/tree/v4.0.1...v4.0.2
+[4.0.1]:https://github.com/MetaMask/obs-store/tree/v4.0.0...v4.0.1
+[4.0.0]:https://github.com/MetaMask/obs-store/tree/v3.0.2...v4.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/obs-store",
-  "version": "1.0.0",
+  "version": "5.0.0",
   "description": "`ObservableStore` is a synchronous in-memory store for a single value, that you can subscribe to updates for.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- Major version bump to `5.0.0`
  - We had played with restarting the version numbers previously, but we won't.
- Update changelog