### PR TITLE
Genericize state wherever possible

### DIFF
--- a/src/ComposedStore.ts
+++ b/src/ComposedStore.ts
@@ -7,13 +7,9 @@ export class ComposedStore<
   private _children: Record<keyof T, ObservableStore<T[keyof T]>>;
 
   constructor(children: Record<keyof T, ObservableStore<T[keyof T]>>) {
-    super();
-    // set default state
-    const state = this.getState();
-    if (!state) {
-      // Typecast: Preserve existing behavior
-      this.putState({} as unknown as T);
-    }
+    // Typecast: Preserve existing behavior
+    super({} as unknown as T);
+
     // subscribe to children
     this._children = children || {};
     Object.keys(this._children).forEach((childKey) => {

--- a/src/ComposedStore.ts
+++ b/src/ComposedStore.ts
@@ -1,15 +1,18 @@
 import { ObservableStore } from './ObservableStore';
 
-export class ComposedStore extends ObservableStore {
+export class ComposedStore<
+  T extends Record<string, Record<string, unknown>>
+> extends ObservableStore<T> {
 
-  _children: Record<string, ObservableStore>;
+  private _children: Record<keyof T, ObservableStore<T[keyof T]>>;
 
-  constructor(children: Record<string, ObservableStore>) {
+  constructor(children: Record<keyof T, ObservableStore<T[keyof T]>>) {
     super();
     // set default state
     const state = this.getState();
     if (!state) {
-      this.putState({});
+      // Typecast: Preserve existing behavior
+      this.putState({} as unknown as T);
     }
     // subscribe to children
     this._children = children || {};
@@ -19,8 +22,8 @@ export class ComposedStore extends ObservableStore {
     });
   }
 
-  _addChild(childKey: string, child: ObservableStore) {
-    const updateFromChild = (childValue: Record<string, unknown>) => {
+  _addChild(childKey: keyof T, child: ObservableStore<T[keyof T]>) {
+    const updateFromChild = (childValue: T[keyof T]) => {
       const state = this.getState();
       state[childKey] = childValue;
       this.putState(state);

--- a/src/MergedStore.ts
+++ b/src/MergedStore.ts
@@ -1,15 +1,16 @@
 import { ObservableStore } from './ObservableStore';
 
-export class MergedStore extends ObservableStore {
+export class MergedStore<T extends Record<string, unknown>> extends ObservableStore<T> {
 
-  private _children: ObservableStore[];
+  private _children: ObservableStore<Partial<T>>[];
 
   constructor(children = []) {
     super();
     // set default state
     const state = this.getState();
     if (!state) {
-      this.putState({});
+      // Typecast: Preserve existing behavior
+      this.putState({} as unknown as T);
     }
     this._children = children;
     // subscribe to children
@@ -17,11 +18,11 @@ export class MergedStore extends ObservableStore {
     this._updateWholeState();
   }
 
-  _addChild(child: ObservableStore) {
+  _addChild(child: ObservableStore<Partial<T>>): void {
     child.subscribe(() => this._updateWholeState());
   }
 
-  _updateWholeState() {
+  _updateWholeState(): void {
     const childStates = this._children.map((child) => child.getState());
     // apply shallow merge over states
     const state = Object.assign({}, ...childStates);

--- a/src/MergedStore.ts
+++ b/src/MergedStore.ts
@@ -1,6 +1,6 @@
 import { ObservableStore } from './ObservableStore';
 
-export class MergedStore<T> extends ObservableStore<T> {
+export class MergedStore<T extends Record<string, unknown>> extends ObservableStore<T> {
 
   private _children: ObservableStore<Partial<T>>[];
 

--- a/src/MergedStore.ts
+++ b/src/MergedStore.ts
@@ -1,6 +1,6 @@
 import { ObservableStore } from './ObservableStore';
 
-export class MergedStore<T extends Record<string, unknown>> extends ObservableStore<T> {
+export class MergedStore<T> extends ObservableStore<T> {
 
   private _children: ObservableStore<Partial<T>>[];
 

--- a/src/MergedStore.ts
+++ b/src/MergedStore.ts
@@ -5,13 +5,9 @@ export class MergedStore<T extends Record<string, unknown>> extends ObservableSt
   private _children: ObservableStore<Partial<T>>[];
 
   constructor(children = []) {
-    super();
-    // set default state
-    const state = this.getState();
-    if (!state) {
-      // Typecast: Preserve existing behavior
-      this.putState({} as unknown as T);
-    }
+    // Typecast: Preserve existing behavior
+    super({} as unknown as T);
+
     this._children = children;
     // subscribe to children
     children.forEach((child) => this._addChild(child));

--- a/src/ObservableStore.ts
+++ b/src/ObservableStore.ts
@@ -4,15 +4,10 @@ export class ObservableStore<T> extends SafeEventEmitter {
 
   private _state: T;
 
-  constructor(initState: T) {
+  // Typecast/default: Preserve existing behavior
+  constructor(initState: T = {} as unknown as T) {
     super();
-
-    if (initState) {
-      this._state = initState;
-    } else {
-      // Typecast: Preserve existing behavior
-      this._state = {} as unknown as T;
-    }
+    this._state = initState;
   }
 
   // wrapper around internal getState

--- a/src/ObservableStore.ts
+++ b/src/ObservableStore.ts
@@ -1,6 +1,6 @@
 import SafeEventEmitter from '@metamask/safe-event-emitter';
 
-export class ObservableStore<T extends Record<string, unknown>> extends SafeEventEmitter {
+export class ObservableStore<T> extends SafeEventEmitter {
 
   private _state: T;
 

--- a/src/ObservableStore.ts
+++ b/src/ObservableStore.ts
@@ -1,27 +1,28 @@
 import SafeEventEmitter from '@metamask/safe-event-emitter';
 
-export class ObservableStore extends SafeEventEmitter {
+export class ObservableStore<T extends Record<string, unknown>> extends SafeEventEmitter {
 
-  private _state: Record<string, unknown>;
+  private _state: T;
 
-  constructor(initState = {}) {
+  // Typecast: Preserve existing behavior
+  constructor(initState: T = {} as unknown as T) {
     super();
     // set init state
     this._state = initState;
   }
 
   // wrapper around internal getState
-  getState() {
+  getState(): T {
     return this._getState();
   }
 
   // wrapper around internal putState
-  putState(newState: Record<string, unknown>) {
+  putState(newState: T): void {
     this._putState(newState);
     this.emit('update', newState);
   }
 
-  updateState(partialState: Record<string, unknown>) {
+  updateState(partialState: T): void {
     // if non-null object, merge
     if (partialState && typeof partialState === 'object') {
       const state = this.getState();
@@ -34,12 +35,12 @@ export class ObservableStore extends SafeEventEmitter {
   }
 
   // subscribe to changes
-  subscribe(handler: (s: Record<string, unknown>) => void) {
+  subscribe(handler: (state: T) => void): void {
     this.on('update', handler);
   }
 
   // unsubscribe to changes
-  unsubscribe(handler: (s: Record<string, unknown>) => void) {
+  unsubscribe(handler: (state: T) => void): void {
     this.removeListener('update', handler);
   }
 
@@ -48,12 +49,12 @@ export class ObservableStore extends SafeEventEmitter {
   //
 
   // read from persistence
-  _getState() {
+  _getState(): T {
     return this._state;
   }
 
   // write to persistence
-  _putState(newState: Record<string, unknown>) {
+  _putState(newState: T): void {
     this._state = newState;
   }
 }

--- a/src/ObservableStore.ts
+++ b/src/ObservableStore.ts
@@ -4,11 +4,15 @@ export class ObservableStore<T extends Record<string, unknown>> extends SafeEven
 
   private _state: T;
 
-  // Typecast: Preserve existing behavior
-  constructor(initState: T = {} as unknown as T) {
+  constructor(initState: T) {
     super();
-    // set init state
-    this._state = initState;
+
+    if (initState) {
+      this._state = initState;
+    } else {
+      // Typecast: Preserve existing behavior
+      this._state = {} as unknown as T;
+    }
   }
 
   // wrapper around internal getState

--- a/src/ObservableStore.ts
+++ b/src/ObservableStore.ts
@@ -30,8 +30,7 @@ export class ObservableStore<T extends Record<string, unknown>> extends SafeEven
     // if non-null object, merge
     if (partialState && typeof partialState === 'object') {
       const state = this.getState();
-      const newState = Object.assign({}, state, partialState);
-      this.putState(newState);
+      this.putState({ ...state, ...partialState });
     // if not object, use new value
     } else {
       this.putState(partialState);
@@ -53,12 +52,12 @@ export class ObservableStore<T extends Record<string, unknown>> extends SafeEven
   //
 
   // read from persistence
-  _getState(): T {
+  protected _getState(): T {
     return this._state;
   }
 
   // write to persistence
-  _putState(newState: T): void {
+  protected _putState(newState: T): void {
     this._state = newState;
   }
 }

--- a/src/asStream.ts
+++ b/src/asStream.ts
@@ -2,9 +2,9 @@ import { Duplex as DuplexStream } from 'stream';
 
 import { ObservableStore } from './ObservableStore';
 
-class ObservableStoreStream<T extends Record<string, unknown>> extends DuplexStream {
+class ObservableStoreStream<T> extends DuplexStream {
 
-  handler: (state: Record<string, unknown>) => void;
+  handler: (state: T) => void;
 
   obsStore: ObservableStore<T>;
 
@@ -16,7 +16,7 @@ class ObservableStoreStream<T extends Record<string, unknown>> extends DuplexStr
     // dont buffer outgoing updates
     this.resume();
     // save handler so we can unsubscribe later
-    this.handler = (state: Record<string, unknown>) => this.push(state);
+    this.handler = (state: T) => this.push(state);
     // subscribe to obsStore changes
     this.obsStore = obsStore;
     this.obsStore.subscribe(this.handler);

--- a/src/asStream.ts
+++ b/src/asStream.ts
@@ -2,13 +2,13 @@ import { Duplex as DuplexStream } from 'stream';
 
 import { ObservableStore } from './ObservableStore';
 
-class ObservableStoreStream extends DuplexStream {
+class ObservableStoreStream<T extends Record<string, unknown>> extends DuplexStream {
 
-  handler: (s: Record<string, unknown>) => void;
+  handler: (state: Record<string, unknown>) => void;
 
-  obsStore: ObservableStore;
+  obsStore: ObservableStore<T>;
 
-  constructor(obsStore: ObservableStore) {
+  constructor(obsStore: ObservableStore<T>) {
     super({
       // pass values, not serializations
       objectMode: true,
@@ -23,7 +23,7 @@ class ObservableStoreStream extends DuplexStream {
   }
 
   // emit current state on new destination
-  pipe<T extends NodeJS.WritableStream>(dest: T, options?: { end?: boolean }): T {
+  pipe<U extends NodeJS.WritableStream>(dest: U, options?: { end?: boolean }): U {
     const result = super.pipe(dest, options);
     dest.write(this.obsStore.getState() as any);
     return result;
@@ -36,7 +36,7 @@ class ObservableStoreStream extends DuplexStream {
   }
 
   // noop - outgoing stream is asking us if we have data we arent giving it
-  _read(_size: number) {
+  _read(_size: number): void {
     return undefined;
   }
 
@@ -47,6 +47,6 @@ class ObservableStoreStream extends DuplexStream {
   }
 }
 
-export function storeAsStream(obsStore: ObservableStore) {
+export function storeAsStream<T extends Record<string, unknown>>(obsStore: ObservableStore<T>): ObservableStoreStream<T> {
   return new ObservableStoreStream(obsStore);
 }

--- a/src/asStream.ts
+++ b/src/asStream.ts
@@ -47,6 +47,6 @@ class ObservableStoreStream<T> extends DuplexStream {
   }
 }
 
-export function storeAsStream<T extends Record<string, unknown>>(obsStore: ObservableStore<T>): ObservableStoreStream<T> {
+export function storeAsStream<T>(obsStore: ObservableStore<T>): ObservableStoreStream<T> {
   return new ObservableStoreStream(obsStore);
 }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,6 +1,9 @@
 import { obj as TransformStream } from 'through2';
 
-export function storeTransformStream(syncTransformFn: (s: Record<string, unknown>) => Record<string, unknown>) {
+export function storeTransformStream<
+  T extends Record<string, unknown>,
+  U extends Record<string, unknown>
+>(syncTransformFn: (state: T) => U) {
   return TransformStream((state, _encoding, cb) => {
     try {
       const newState = syncTransformFn(state);

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,9 +1,6 @@
 import { obj as TransformStream } from 'through2';
 
-export function storeTransformStream<
-  T extends Record<string, unknown>,
-  U extends Record<string, unknown>
->(syncTransformFn: (state: T) => U) {
+export function storeTransformStream<T, U>(syncTransformFn: (state: T) => U) {
   return TransformStream((state, _encoding, cb) => {
     try {
       const newState = syncTransformFn(state);


### PR DESCRIPTION
Rather than just typing the store state as `Record<string, unknown>` everywhere (not very helpful, we were just lazy), we now type it as `T extends Record<string, unknown>`. This will be really neat to use in practice.

To preserve existing behavior, we cheat in a three places by continuing to default the state to `{}`, regardless of the generic type. Excepting `LocalStorageStore` (which should really be rewritten to solve this problem), type safety still cannot be violated by the consumer if TypeScript is used.