### PR TITLE
6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [6.0.0] - 2020-02-05
+
+### Changed
+
+- Genericize state in all classes / exports ([#33](https://github.com/MetaMask/obs-store/pull/33))
+
+### Removed
+
+- **(BREAKING)** Remove `LocalStorageStore` ([#34](https://github.com/MetaMask/obs-store/pull/34))
+
 ## [5.0.0] - 2020-12-16
 
 ### Added
@@ -19,7 +29,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   - All exports are now named, and exposed at the main entry point.
   - Some export names have changed, but they should still be recognizable.
 
-[Unreleased]:https://github.com/MetaMask/obs-store/compare/v5.0.0...HEAD
+[Unreleased]:https://github.com/MetaMask/obs-store/compare/v6.0.0...HEAD
+[6.0.0]:https://github.com/MetaMask/obs-store/compare/v5.0.0...v6.0.0
 [5.0.0]:https://github.com/MetaMask/obs-store/tree/v4.0.3...v5.0.0
 [4.0.3]:https://github.com/MetaMask/obs-store/tree/v4.0.2...v4.0.3
 [4.0.2]:https://github.com/MetaMask/obs-store/tree/v4.0.1...v4.0.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/obs-store",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "`ObservableStore` is a synchronous in-memory store for a single value, that you can subscribe to updates for.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- Major version bump
  - The removal of `LocalStorageStore` is breaking, type updates may be breaking
- Update changelog