### PR TITLE
Fix build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dist/"
   ],
   "scripts": {
-    "build": "tsc --project .",
+    "build": "rm -rf ./dist && tsc --project .",
     "test": "yarn build && tape test/**/*.js",
     "lint": "eslint . --ext ts,js,json",
     "lint:fix": "yarn lint --fix",


### PR DESCRIPTION
We need to delete the contents of the dist directory between builds to ensure old files aren't persisted and published.