### PR TITLE
Fix ObservableStore.updateState and constructor type bugs

### DIFF
--- a/src/ObservableStore.ts
+++ b/src/ObservableStore.ts
@@ -4,10 +4,14 @@ export class ObservableStore<T> extends SafeEventEmitter {
 
   private _state: T;
 
-  // Typecast/default: Preserve existing behavior
-  constructor(initState: T = {} as unknown as T) {
+  constructor(initState: T) {
     super();
-    this._state = initState;
+    if (initState) {
+      this._state = initState;
+    } else {
+      // Typecast/default state: Preserve existing behavior
+      this._state = {} as unknown as T;
+    }
   }
 
   // wrapper around internal getState
@@ -21,7 +25,7 @@ export class ObservableStore<T> extends SafeEventEmitter {
     this.emit('update', newState);
   }
 
-  updateState(partialState: T): void {
+  updateState(partialState: Partial<T>): void {
     // if non-null object, merge
     if (partialState && typeof partialState === 'object') {
       const state = this.getState();


### PR DESCRIPTION
Fixes:
- Constructor was typed to allow no default state
  - We preserve a default state initialization under the hood to preserve backwards incompatibility for JavaScript consumers
- updateState must accept a `Partial<T>` where `T` is its generic type