### PR TITLE
Remove `readable-stream`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "license": "ISC",
   "dependencies": {
     "@metamask/safe-event-emitter": "^2.0.0",
-    "readable-stream": "^2.2.2",
     "through2": "^2.0.3"
   },
   "devDependencies": {

--- a/test/stream.js
+++ b/test/stream.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const TransformStream = require('stream').Transform;
 const test = require('tape');
-const TransformStream = require('readable-stream').Transform;
 const streamUtils = require('mississippi');
 
 const { pipe } = streamUtils;


### PR DESCRIPTION
This package was only being used in tests. The tests are always run in `Node.js`, so I switched them to use the built-in Node.js stream API instead.

I'm guessing this package was originally included to allow using this package in either the browser or Node.js. But it wasn't setup that way. I did consider using `readable-stream` in place of `stream` to make browser compatibility easier for consumers, but that would have required more effort to get working, as the version of `readable-stream` in-use was outdated and incompatible with this package. Plus it's fairly common for bundlers to replace built-in modules like `stream` on-the-fly so it would have been of marginal benefit.