### PR TITLE
Use `rimraf` for build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dist/"
   ],
   "scripts": {
-    "build": "rm -rf ./dist && tsc --project .",
+    "build": "rimraf dist && tsc --project .",
     "test": "yarn build && tape test/**/*.js",
     "lint": "eslint . --ext ts,js,json",
     "lint:fix": "yarn lint --fix",
@@ -33,6 +33,7 @@
     "eslint-plugin-json": "^2.1.2",
     "eslint-plugin-node": "^11.1.0",
     "mississippi": "^1.2.0",
+    "rimraf": "^3.0.2",
     "tape": "^4.6.3",
     "typescript": "^4.1.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1471,6 +1471,13 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 run-parallel@^1.1.9:
   version "1.1.10"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.10.tgz#60a51b2ae836636c81377df16cb107351bcd13ef"


### PR DESCRIPTION
`rimraf` is now used for the build script to remove the `dist` directory, rather than `rm -rf`. This is equivalent except that it also works on Windows.