### PR TITLE
Add `publishConfig` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,10 @@
   "engines": {
     "node": ">=12.0.0"
   },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "lavamoat": {
     "allowScripts": {
       "@lavamoat/preinstall-always-fail": false


### PR DESCRIPTION
This sets the access to "public" when publishing (it's set to "restricted" by default).