### PR TITLE
Allow falsy initial state

### DIFF
--- a/src/ObservableStore.ts
+++ b/src/ObservableStore.ts
@@ -5,11 +5,11 @@ export class ObservableStore<T> extends SafeEventEmitter {
 
   constructor(initState: T) {
     super();
-    if (initState) {
-      this._state = initState;
-    } else {
+    if (initState === undefined) {
       // Typecast/default state: Preserve existing behavior
       this._state = {} as unknown as T;
+    } else {
+      this._state = initState;
     }
   }
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -22,6 +22,43 @@ test('basic', function (t) {
   }
 });
 
+test('default state', function (t) {
+  t.plan(3);
+
+  const nextState = 'next';
+
+  const store = new ObservableStore();
+  store.subscribe(valueCheck);
+
+  t.deepEqual(store.getState(), {}, 'default state of empty object is set');
+
+  store.putState(nextState);
+  t.equal(store.getState(), nextState, 'state is nextState');
+
+  function valueCheck(value) {
+    t.equal(value, nextState, 'subscribed: state is nextState');
+  }
+});
+
+test('falsy non-undefined initial state', function (t) {
+  t.plan(3);
+
+  const initState = null;
+  const nextState = 'next';
+
+  const store = new ObservableStore(initState);
+  store.subscribe(valueCheck);
+
+  t.equal(store.getState(), initState, 'null default state is set');
+
+  store.putState(nextState);
+  t.equal(store.getState(), nextState, 'state is nextState');
+
+  function valueCheck(value) {
+    t.equal(value, nextState, 'subscribed: state is nextState');
+  }
+});
+
 test('updateState', function (t) {
   t.plan(2);
 


### PR DESCRIPTION
This library has used an empty object as the default initial state ever since the initial version, but in older versions that was only set if the initial state was undefined. An initial state of `null` or any other falsy value other than `undefined`  was still accepted.

In #38 (published as part of v6.0.2) this was accidentally changed. Instead the empty object default was used for any falsy value passed in as the initial state.

The pre-v6.0.2 behavior has now been restored; falsy initial state is no longer overwritten.