### PR TITLE
Convert tests to TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@metamask/eslint-config": "^7.0.1",
     "@metamask/eslint-config-typescript": "^7.0.1",
     "@types/node": "^10.17.42",
+    "@types/tape": "^4.13.4",
     "@types/through2": "^2.0.36",
     "@typescript-eslint/eslint-plugin": "^4.28.1",
     "@typescript-eslint/parser": "^4.28.1",

--- a/test/basic.ts
+++ b/test/basic.ts
@@ -1,7 +1,5 @@
-const test = require('tape');
-
-// eslint-disable-next-line import/no-unresolved
-const { ObservableStore } = require('../dist');
+import test from 'tape';
+import { ObservableStore } from '../src';
 
 test('basic', function (t) {
   t.plan(3);
@@ -27,6 +25,8 @@ test('default state', function (t) {
 
   const nextState = 'next';
 
+  // @ts-expect-error The signature for the ObservableStore constructor makes it
+  // seem like an argument is required, but we're not passing an argument here.
   const store = new ObservableStore();
   store.subscribe(valueCheck);
 
@@ -76,6 +76,8 @@ test('updateState non-obj onto obj', function (t) {
 
   const storeOne = new ObservableStore({ a: true });
 
+  // @ts-expect-error We're intentionally trying to update an object state with
+  // a non-object.
   storeOne.updateState(2);
   const state = storeOne.getState();
 
@@ -88,9 +90,14 @@ test('updateState obj onto non-obj', function (t) {
 
   const storeOne = new ObservableStore(2);
 
+  // @ts-expect-error We're intentionally trying to update an non-object state
+  // with an object.
   storeOne.updateState({ a: true });
   const state = storeOne.getState();
 
   t.equal(typeof state, 'object', 'value is wholly overwritten by object');
+  // @ts-expect-error The interface for `ObservableStore` does not allow
+  // changing the type of the whole state, but `updateState` overwrites the
+  // state object anyway.
   t.equal(state.a, true, 'a is present');
 });

--- a/test/composed.ts
+++ b/test/composed.ts
@@ -1,17 +1,21 @@
-'use strict';
-
-const test = require('tape');
-
-// eslint-disable-next-line import/no-unresolved
-const { ComposedStore, ObservableStore } = require('../dist');
+import test from 'tape';
+import { ComposedStore, ObservableStore } from '../src';
 
 test('ComposedStore - basic', function (t) {
   t.plan(1);
 
+  // @ts-expect-error The signature for the ObservableStore constructor makes it
+  // seem like an argument is required, but we're not passing an argument here.
   const childStoreOne = new ObservableStore();
+  // @ts-expect-error The signature for the ObservableStore constructor makes it
+  // seem like an argument is required, but we're not passing an argument here.
   const childStoreTwo = new ObservableStore();
   const composedStore = new ComposedStore({
+    // @ts-expect-error TypeScript produces an error because ComposedStore
+    // isn't typed correctly.
     one: childStoreOne,
+    // @ts-expect-error TypeScript produces an error because ComposedStore
+    // isn't typed correctly.
     two: childStoreTwo,
   });
 
@@ -31,7 +35,11 @@ test('ComposedStore - child initState', function (t) {
   const childStoreOne = new ObservableStore(1);
   const childStoreTwo = new ObservableStore(2);
   const composedStore = new ComposedStore({
+    // @ts-expect-error TypeScript produces an error because ComposedStore
+    // isn't typed correctly.
     one: childStoreOne,
+    // @ts-expect-error TypeScript produces an error because ComposedStore
+    // isn't typed correctly.
     two: childStoreTwo,
   });
 

--- a/test/merged.ts
+++ b/test/merged.ts
@@ -1,14 +1,14 @@
-'use strict';
-
-const test = require('tape');
-
-// eslint-disable-next-line import/no-unresolved
-const { MergedStore, ObservableStore } = require('../dist');
+import test from 'tape';
+import { MergedStore, ObservableStore } from '../src';
 
 test('MergedStore - basic', function (t) {
   t.plan(1);
 
+  // @ts-expect-error The signature for the ObservableStore constructor makes it
+  // seem like an argument is required, but we're not passing an argument here.
   const childStoreOne = new ObservableStore();
+  // @ts-expect-error The signature for the ObservableStore constructor makes it
+  // seem like an argument is required, but we're not passing an argument here.
   const childStoreTwo = new ObservableStore();
   const mergedStore = new MergedStore([childStoreOne, childStoreTwo]);
 

--- a/test/stream.ts
+++ b/test/stream.ts
@@ -1,13 +1,7 @@
-'use strict';
-
-const TransformStream = require('stream').Transform;
-const test = require('tape');
-const streamUtils = require('mississippi');
-
-const { pipe } = streamUtils;
-const writeStream = streamUtils.to;
-// eslint-disable-next-line import/no-unresolved
-const { ObservableStore, storeAsStream } = require('../dist');
+import { Transform as TransformStream } from 'stream';
+import test from 'tape';
+import { pipe, to as writeStream } from 'mississippi';
+import { ObservableStore, storeAsStream } from '../src';
 
 const TEST_WAIT = 200;
 
@@ -18,6 +12,8 @@ test('basic stream', function (t) {
   const nextState = 'next';
 
   const storeOne = new ObservableStore(initState);
+  // @ts-expect-error The signature for the ObservableStore constructor makes it
+  // seem like an argument is required, but we're not passing an argument here.
   const storeTwo = new ObservableStore();
   storeTwo.once('update', (value) => {
     initValueCheck(value);
@@ -44,6 +40,8 @@ test('double stream', function (t) {
   const nextState = 'next';
 
   const storeOne = new ObservableStore(initState);
+  // @ts-expect-error The signature for the ObservableStore constructor makes it
+  // seem like an argument is required, but we're not passing an argument here.
   const storeTwo = new ObservableStore();
   storeTwo.once('update', (initValue) => {
     initValueCheck('storeTwo', initValue);
@@ -52,6 +50,8 @@ test('double stream', function (t) {
     );
   });
 
+  // @ts-expect-error The signature for the ObservableStore constructor makes it
+  // seem like an argument is required, but we're not passing an argument here.
   const storeThree = new ObservableStore();
   storeThree.once('update', (initValue) => {
     initValueCheck('storeThree', initValue);
@@ -90,6 +90,8 @@ test('transform stream', function (t) {
   });
 
   const storeOne = new ObservableStore(initState);
+  // @ts-expect-error The signature for the ObservableStore constructor makes it
+  // seem like an argument is required, but we're not passing an argument here.
   const storeTwo = new ObservableStore();
   storeTwo.once('update', (value) => {
     initValueCheck(value);
@@ -122,6 +124,8 @@ test('transform stream', function (t) {
 test('basic - stream buffering', function (t) {
   t.plan(2);
 
+  // @ts-expect-error The signature for the ObservableStore constructor makes it
+  // seem like an argument is required, but we're not passing an argument here.
   const store = new ObservableStore();
   store.putState(1);
   store.putState(2);
@@ -157,6 +161,8 @@ test('basic - stream buffering', function (t) {
 test('basic - stream destroy unsubscribe', function (t) {
   t.plan(4);
 
+  // @ts-expect-error The signature for the ObservableStore constructor makes it
+  // seem like an argument is required, but we're not passing an argument here.
   const store = new ObservableStore();
   t.equal(store.listenerCount('update'), 0);
 

--- a/test/transform.ts
+++ b/test/transform.ts
@@ -1,15 +1,6 @@
-'use strict';
-
-const test = require('tape');
-const streamUtils = require('mississippi');
-const {
-  ObservableStore,
-  storeAsStream,
-  storeTransformStream,
-  // eslint-disable-next-line import/no-unresolved
-} = require('../dist');
-
-const { pipe } = streamUtils;
+import test from 'tape';
+import { pipe } from 'mississippi';
+import { ObservableStore, storeAsStream, storeTransformStream } from '../src';
 
 test('storeTransformStream test', function (t) {
   t.plan(4);
@@ -23,6 +14,8 @@ test('storeTransformStream test', function (t) {
   });
 
   const storeOne = new ObservableStore(initState);
+  // @ts-expect-error The signature for the ObservableStore constructor makes it
+  // seem like an argument is required, but we're not passing an argument here.
   const storeTwo = new ObservableStore();
   storeTwo.once('update', (value) => {
     initValueCheck(value);

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,10 +163,25 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.42.tgz#90dd71b26fe4f4e2929df6b07e72ef2e9648a173"
   integrity sha512-HElxYF7C/MSkuvlaHB2c+82zhXiuO49Cq056Dol8AQuTph7oJtduo2n6J8rFa+YhJyNgQ/Lm20ZaxqD0vxU0+Q==
 
+"@types/tape@^4.13.4":
+  version "4.13.4"
+  resolved "https://registry.yarnpkg.com/@types/tape/-/tape-4.13.4.tgz#2fe220e9040c1721e5b1af6cd71e9e018d07cafb"
+  integrity sha512-0Mw8/FAMheD2MvyaFYDaAix7X5GfNjl/XI+zvqJdzC6N05BmHKz6Hwn+r7+8PEXDEKrC3V/irC9z7mrl5a130g==
+  dependencies:
+    "@types/node" "*"
+    "@types/through" "*"
+
 "@types/through2@^2.0.36":
   version "2.0.36"
   resolved "https://registry.yarnpkg.com/@types/through2/-/through2-2.0.36.tgz#35fda0db635827d44c0e08e2c94653e647574a00"
   integrity sha512-vuifQksQHJXhV9McpVsXKuhnf3lsoX70PnhcqIAbs9dqLH2NgrGz0DzZPDY3+Yh6eaRqcE1gnCQ6QhBn1/PT5A==
+  dependencies:
+    "@types/node" "*"
+
+"@types/through@*":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@types/through/-/through-0.0.30.tgz#e0e42ce77e897bd6aead6f6ea62aeb135b8a3895"
+  integrity sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==
   dependencies:
     "@types/node" "*"
 


### PR DESCRIPTION
We need to fix a bug with the types for ComposedStore, but before we can do that, we need to verify that the fix works. Converting the tests to TypeScript should help.

Note that doing this has revealed another bug with the type for the ObservableStore constructor. We will address that bug in a future commit.