### PR TITLE
Fix ComposedStore types to account for primitives

### DIFF
--- a/src/ComposedStore.ts
+++ b/src/ComposedStore.ts
@@ -1,7 +1,7 @@
 import { ObservableStore } from './ObservableStore';
 
 export class ComposedStore<
-  T extends Record<string, Record<string, unknown>>,
+  T extends Record<string, unknown>,
 > extends ObservableStore<T> {
   private _children: Record<keyof T, ObservableStore<T[keyof T]>>;
 

--- a/test/composed.ts
+++ b/test/composed.ts
@@ -1,7 +1,7 @@
 import test from 'tape';
 import { ComposedStore, ObservableStore } from '../src';
 
-test('ComposedStore - basic', function (t) {
+test('ComposedStore - unknown state', function (t) {
   t.plan(1);
 
   // @ts-expect-error The signature for the ObservableStore constructor makes it
@@ -11,11 +11,7 @@ test('ComposedStore - basic', function (t) {
   // seem like an argument is required, but we're not passing an argument here.
   const childStoreTwo = new ObservableStore();
   const composedStore = new ComposedStore({
-    // @ts-expect-error TypeScript produces an error because ComposedStore
-    // isn't typed correctly.
     one: childStoreOne,
-    // @ts-expect-error TypeScript produces an error because ComposedStore
-    // isn't typed correctly.
     two: childStoreTwo,
   });
 
@@ -29,23 +25,45 @@ test('ComposedStore - basic', function (t) {
   );
 });
 
-test('ComposedStore - child initState', function (t) {
+test('ComposedStore - primitive state', function (t) {
   t.plan(1);
 
   const childStoreOne = new ObservableStore(1);
   const childStoreTwo = new ObservableStore(2);
   const composedStore = new ComposedStore({
-    // @ts-expect-error TypeScript produces an error because ComposedStore
-    // isn't typed correctly.
     one: childStoreOne,
-    // @ts-expect-error TypeScript produces an error because ComposedStore
-    // isn't typed correctly.
     two: childStoreTwo,
   });
 
+  childStoreOne.putState(2);
+  childStoreTwo.putState(4);
+
   t.deepEqual(
     composedStore.getState(),
-    { one: 1, two: 2 },
+    { one: 2, two: 4 },
+    'composedStore gets state from children',
+  );
+});
+
+test('ComposedStore - non-primitive state', function (t) {
+  t.plan(1);
+
+  const childStoreOne = new ObservableStore({ foo: 'bar' });
+  const childStoreTwo = new ObservableStore({ baz: 'qux' });
+  const composedStore = new ComposedStore({
+    one: childStoreOne,
+    two: childStoreTwo,
+  });
+
+  childStoreOne.putState({ foo: 'fizz' });
+  childStoreTwo.putState({ baz: 'buzz' });
+
+  t.deepEqual(
+    composedStore.getState(),
+    {
+      one: { foo: 'buzz' },
+      two: { baz: 'buzz' },
+    },
     'composedStore gets state from children',
   );
 });


### PR DESCRIPTION
When using CompositeStore, it is possible for the type of the contents of a child store to be a primitive. The type of CompositeStore assumes that it is always an object, so simplify this.