### PR TITLE
ci: change runner image from ubuntu-20.04 to ubuntu-latest

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-lint-test:
     name: Build, Lint, and Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [12.x, 14.x, 16.x]
@@ -42,7 +42,7 @@ jobs:
         run: yarn auto-changelog validate
   all-jobs-pass:
     name: All jobs pass
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs:
       - build-lint-test
     steps:


### PR DESCRIPTION
`ubuntu-latest` is now pointing at current LTS `ubuntu-22.04` since some time.