### PR TITLE
feat: Allow overriding default Stream options

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@metamask/eslint-config": "^7.0.1",
     "@metamask/eslint-config-typescript": "^7.0.1",
     "@types/node": "^10.17.42",
+    "@types/readable-stream": "4.0.0",
     "@types/tape": "^4.13.4",
     "@typescript-eslint/eslint-plugin": "^4.28.1",
     "@typescript-eslint/parser": "^4.28.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@metamask/auto-changelog": "^3.4.2",
     "@metamask/eslint-config": "^7.0.1",
     "@metamask/eslint-config-typescript": "^7.0.1",
-    "@types/node": "^10.17.42",
+    "@types/node": "^14.18.63",
     "@types/readable-stream": "4.0.0",
     "@types/tape": "^4.13.4",
     "@typescript-eslint/eslint-plugin": "^4.28.1",

--- a/src/asStream.ts
+++ b/src/asStream.ts
@@ -1,4 +1,5 @@
 import { Duplex as DuplexStream } from 'readable-stream';
+import type { DuplexOptions } from 'readable-stream';
 
 import { ObservableStore } from './ObservableStore';
 
@@ -7,10 +8,11 @@ class ObservableStoreStream<T> extends DuplexStream {
 
   obsStore: ObservableStore<T>;
 
-  constructor(obsStore: ObservableStore<T>) {
+  constructor(obsStore: ObservableStore<T>, streamOptions: DuplexOptions = {}) {
     super({
       // pass values, not serializations
       objectMode: true,
+      ...streamOptions,
     });
     // dont buffer outgoing updates
     this.resume();
@@ -55,6 +57,7 @@ class ObservableStoreStream<T> extends DuplexStream {
 
 export function storeAsStream<T>(
   obsStore: ObservableStore<T>,
+  streamOptions: DuplexOptions = {},
 ): ObservableStoreStream<T> {
-  return new ObservableStoreStream(obsStore);
+  return new ObservableStoreStream(obsStore, streamOptions);
 }

--- a/src/readable-stream.d.ts
+++ b/src/readable-stream.d.ts
@@ -1,4 +1,5 @@
 // eslint-disable import/unambiguous
 declare module 'readable-stream' {
   export { Duplex, Transform, Writable, pipeline } from 'stream';
+  export type { DuplexOptions, TransformOptions } from 'stream';
 }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,9 +1,17 @@
 import { Transform } from 'readable-stream';
+import type { TransformOptions } from 'readable-stream';
 
-export function storeTransformStream<T, U>(syncTransformFn: (state: T) => U) {
+export function storeTransformStream<T, U>(
+  syncTransformFn: (state: T) => U,
+  streamOptions: TransformOptions = {},
+) {
   const t = new Transform({
     objectMode: true,
-    transform: (state, _encoding, cb) => {
+    transform: (
+      state: T,
+      _encoding: unknown,
+      cb: (error?: Error | null, data?: U) => void,
+    ) => {
       try {
         const newState = syncTransformFn(state);
         cb(undefined, newState);
@@ -13,6 +21,7 @@ export function storeTransformStream<T, U>(syncTransformFn: (state: T) => U) {
         return undefined;
       }
     },
+    ...streamOptions,
   });
   return t;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -188,6 +188,14 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.42.tgz#90dd71b26fe4f4e2929df6b07e72ef2e9648a173"
   integrity sha512-HElxYF7C/MSkuvlaHB2c+82zhXiuO49Cq056Dol8AQuTph7oJtduo2n6J8rFa+YhJyNgQ/Lm20ZaxqD0vxU0+Q==
 
+"@types/readable-stream@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/readable-stream/-/readable-stream-4.0.0.tgz#9bcb888b9c77478b02490365d3e0c34fd8b6d5ae"
+  integrity sha512-s6YqDV111kwuFsT9SwFC+FmZ5n1SEp4H9DXGg6Zqag0lPGeEvBGP9UaLJYpX4cxY7fAFnx2avy1QVvft0LLb7g==
+  dependencies:
+    "@types/node" "*"
+    safe-buffer "~5.1.1"
+
 "@types/tape@^4.13.4":
   version "4.13.4"
   resolved "https://registry.yarnpkg.com/@types/tape/-/tape-4.13.4.tgz#2fe220e9040c1721e5b1af6cd71e9e018d07cafb"
@@ -2032,6 +2040,11 @@ run-parallel@^1.1.9:
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.10.tgz#60a51b2ae836636c81377df16cb107351bcd13ef"
   integrity sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==
 
+safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
 safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
@@ -2172,7 +2185,16 @@ ssri@^10.0.0:
   dependencies:
     minipass "^5.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2222,7 +2244,14 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -2450,7 +2479,16 @@ word-wrap@^1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.4.tgz#cb4b50ec9aca570abd1f52f33cd45b6c61739a9f"
   integrity sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -179,14 +179,16 @@
   integrity sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==
 
 "@types/node@*":
-  version "14.14.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.2.tgz#d25295f9e4ca5989a2c610754dc02a9721235eeb"
-  integrity sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg==
+  version "20.12.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.12.tgz#7cbecdf902085cec634fdb362172dfe12b8f2050"
+  integrity sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==
+  dependencies:
+    undici-types "~5.26.4"
 
-"@types/node@^10.17.42":
-  version "10.17.42"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.42.tgz#90dd71b26fe4f4e2929df6b07e72ef2e9648a173"
-  integrity sha512-HElxYF7C/MSkuvlaHB2c+82zhXiuO49Cq056Dol8AQuTph7oJtduo2n6J8rFa+YhJyNgQ/Lm20ZaxqD0vxU0+Q==
+"@types/node@^14.18.63":
+  version "14.18.63"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.63.tgz#1788fa8da838dbb5f9ea994b834278205db6ca2b"
+  integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
 
 "@types/readable-stream@4.0.0":
   version "4.0.0"
@@ -2402,6 +2404,11 @@ unbox-primitive@^1.0.1:
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 unique-filename@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
- feat: Allow overriding stream constructor options in `storeTransformStream`
- feat: Allow overriding stream constructor options in `ObservableStoreStream` constructor
- feat: Allow overriding stream constructor options in `storeAsStream` function
- chore: add `@types/readable-stream`
  - _See commit message for details and [`object-multiplex`](https://github.com/MetaMask/object-multiplex) for another package in a similar situation already using the same approach_
- chore: update `@types/node` from v10 to v14