### PR TITLE
chore: declare yarn version 1.22.22 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "typescript": "^4.1.3"
   },
   "engines": {
-    "node": "^14.21 || ^16.20 || ^18.16 || >=20"
+    "node": "^14.21 || ^16.20 || ^18.16 || >=20",
+    "yarn": "^1.22.22"
   },
   "publishConfig": {
     "access": "public",
@@ -61,5 +62,6 @@
     "allowScripts": {
       "@lavamoat/preinstall-always-fail": false
     }
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
Pin current (latest) yarn v1.x version in order to make `corepack enable` pick up the correct version when working with this repo.

### Related
- https://github.com/MetaMask/metamask-mobile/pull/9143